### PR TITLE
Feature/errors try 1

### DIFF
--- a/doc/decisions/1-error-handling.md
+++ b/doc/decisions/1-error-handling.md
@@ -1,0 +1,28 @@
+
+Each endpoint has a response type or a specific api error type for that endpoint, lets call it `ExampleAPIError` from now on.
+
+My functions have signatures such as this:
+`fn example_api() -> Result<Response<ExampleResult>>`
+
+The result comes from the generated error module using error_chain and the response is a generic struct that wraps a body as follows
+```
+pub struct Response<T> {
+    pub body: T,
+}
+```
+
+I would like to return the potential error deserialized from the `example_api()` function since we already have that information
+ahead of time. I feel like I have 3 possible solutions:
+1. Make the api error part of the error_chain error in a big `APIErrors` enum for all the type 
+of API errors and document that this `example_api()` can return errors of that type.
+The disadvantage here is that I feel like I am losing some information since the error
+seems important enough that it should maybe be encoded in function signature.
+
+2. Make the Response an enum that holds either a body or an APIError. This is a little 
+analogous to the Result type but the disadvantage is that we are duplicating the error handling 
+since a user of that function would have to handle errors twice and since my `Response` type isn't a 
+result type won't benefit from using the `?` operator.
+
+3. Similar to the above, make the Response an enum but map the error to the error case of the Result. 
+This is quite ugly and will also confuse users since even though the Response type is an enum, 
+it should essentially never actually be the error case. 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -121,9 +121,10 @@ impl AuthOperations {
         Ok(serde_json::from_reader(res)?)
     }
 
-    fn rpc_request<T, R>(&self, url: Url, request_body: T) -> Result<Response<R>>
+    fn rpc_request<T, R, E>(&self, url: Url, request_body: T) -> Result<Response<R, E>>
         where T: Serialize,
-              R: DeserializeOwned
+              R: DeserializeOwned,
+              E: DeserializeOwned
     {
         let client = Client::new();
         let res = client.post(url)
@@ -133,7 +134,8 @@ impl AuthOperations {
 
         Ok(Response::try_from(res)?)
     }
-    pub fn token_from_oauth1(&self) -> Result<Response<TokenFromOAuth1Result>> {
+    // TODO fix error
+    pub fn token_from_oauth1(&self) -> Result<Response<TokenFromOAuth1Result, ()>> {
         let url = Url::parse("https://api.dropboxapi.com/2/auth/token/from_oauth1")?;
         self.rpc_request(url,
                          &TokenFromOAuth1Arg {
@@ -144,13 +146,13 @@ impl AuthOperations {
 }
 
 pub trait RevokableToken {
-    fn revoke_token(&self) -> Result<Response<()>>;
+    fn revoke_token(&self) -> Result<Response<(), ()>>;
 }
 
 impl<C> RevokableToken for C
     where C: RPCClient
 {
-    fn revoke_token(&self) -> Result<Response<()>> {
+    fn revoke_token(&self) -> Result<Response<(), ()>> {
         let url = Url::parse(BASE_URL)?.join("revoke")?;
         self.rpc_request(url, ())
     }

--- a/src/paper/mod.rs
+++ b/src/paper/mod.rs
@@ -17,7 +17,9 @@ use self::users::{AddPaperDocUserRequestBuilder, UserOnPaperDocFilter, ListUsers
 
 static BASE_URL: &'static str = "https://api.dropboxapi.com/2/paper/docs/";
 
-pub fn archive<T: RPCClient>(client: &T, doc_id: &str) -> Result<Response<()>> {
+pub fn archive<T: RPCClient>(client: &T,
+                             doc_id: &str)
+                             -> Result<Response<(), self::errors::DocLookupError>> {
     let url = Url::parse(BASE_URL)?
         .join("archive")?;
     println!("{}", url);
@@ -26,210 +28,210 @@ pub fn archive<T: RPCClient>(client: &T, doc_id: &str) -> Result<Response<()>> {
     client.rpc_request(url, request)
 }
 
-pub fn create<T: ContentUploadClient, C: Into<Body>>
-    (client: &T,
-     import_format: ImportFormat,
-     parent_folder_id: Option<&str>,
-     content: C)
-     -> Result<Response<PaperDocCreateUpdateResult>> {
-    let url = Url::parse(BASE_URL)?
-        .join("create")?;
-    println!("{}", url);
+// pub fn create<T: ContentUploadClient, C: Into<Body>>
+//     (client: &T,
+//      import_format: ImportFormat,
+//      parent_folder_id: Option<&str>,
+//      content: C)
+//      -> Result<Response<PaperDocCreateUpdateResult>> {
+//     let url = Url::parse(BASE_URL)?
+//         .join("create")?;
+//     println!("{}", url);
 
-    client.content_upload_request(url,
-                                  PaperDocCreateArgs {
-                                      import_format: import_format,
-                                      parent_folder_id: parent_folder_id.map(|x| x.to_owned()),
-                                  },
-                                  content)
-}
+//     client.content_upload_request(url,
+//                                   PaperDocCreateArgs {
+//                                       import_format: import_format,
+//                                       parent_folder_id: parent_folder_id.map(|x| x.to_owned()),
+//                                   },
+//                                   content)
+// }
 
-pub fn download<C, T: ContentDownloadClient<C>>
-    (client: &T,
-     doc_id: &str,
-     export_format: ExportFormat)
-     -> Result<ContentResponse<PaperDocExportResult, C>>
-    where C: Read
-{
-    let url = Url::parse(BASE_URL)?
-        .join("download")?;
-    println!("{}", url);
-    client.content_download(url,
-                            PaperDocExport {
-                                doc_id: doc_id.to_owned(),
-                                export_format: export_format,
-                            })
-}
+// pub fn download<C, T: ContentDownloadClient<C>>
+//     (client: &T,
+//      doc_id: &str,
+//      export_format: ExportFormat)
+//      -> Result<ContentResponse<PaperDocExportResult, C>>
+//     where C: Read
+// {
+//     let url = Url::parse(BASE_URL)?
+//         .join("download")?;
+//     println!("{}", url);
+//     client.content_download(url,
+//                             PaperDocExport {
+//                                 doc_id: doc_id.to_owned(),
+//                                 export_format: export_format,
+//                             })
+// }
 
-pub fn list_folder_users<T: RPCClient>(client: &T,
-                                       doc_id: &str,
-                                       limit: i32)
-                                       -> Result<Response<ListUsersOnFolderResponse>> {
-    let url = Url::parse(BASE_URL)?.join("folder_users/list")?;
-    println!("{}", url);
-    client.rpc_request(url,
-                       &ListUsersOnFolderArgs {
-                           doc_id: doc_id.to_owned(),
-                           limit: limit,
-                       })
-}
+// pub fn list_folder_users<T: RPCClient>(client: &T,
+//                                        doc_id: &str,
+//                                        limit: i32)
+//                                        -> Result<Response<ListUsersOnFolderResponse>> {
+//     let url = Url::parse(BASE_URL)?.join("folder_users/list")?;
+//     println!("{}", url);
+//     client.rpc_request(url,
+//                        &ListUsersOnFolderArgs {
+//                            doc_id: doc_id.to_owned(),
+//                            limit: limit,
+//                        })
+// }
 
-pub fn list_folder_users_continue<T: RPCClient>(client: &T,
-                                                doc_id: &str,
-                                                cursor: &str)
-                                                -> Result<Response<ListUsersOnFolderResponse>> {
-    let url = Url::parse(BASE_URL)?.join("folder_users/list/continue")?;
-    println!("{}", url);
-    client.rpc_request(url,
-                       &ListUsersOnFolderContinueArgs {
-                           doc_id: doc_id.to_owned(),
-                           cursor: cursor.to_owned(),
-                       })
-}
+// pub fn list_folder_users_continue<T: RPCClient>(client: &T,
+//                                                 doc_id: &str,
+//                                                 cursor: &str)
+//                                                 -> Result<Response<ListUsersOnFolderResponse>> {
+//     let url = Url::parse(BASE_URL)?.join("folder_users/list/continue")?;
+//     println!("{}", url);
+//     client.rpc_request(url,
+//                        &ListUsersOnFolderContinueArgs {
+//                            doc_id: doc_id.to_owned(),
+//                            cursor: cursor.to_owned(),
+//                        })
+// }
 
-pub fn get_folder_info<T: RPCClient>(client: &T,
-                                     doc_id: &str)
-                                     -> Result<Response<FoldersContainingPaperDoc>> {
-    let url = Url::parse(BASE_URL)?.join("get_folder_info")?;
-    println!("{}", url);
-    client.rpc_request(url, &RefPaperDoc { doc_id: doc_id.to_owned() })
-}
+// pub fn get_folder_info<T: RPCClient>(client: &T,
+//                                      doc_id: &str)
+//                                      -> Result<Response<FoldersContainingPaperDoc>> {
+//     let url = Url::parse(BASE_URL)?.join("get_folder_info")?;
+//     println!("{}", url);
+//     client.rpc_request(url, &RefPaperDoc { doc_id: doc_id.to_owned() })
+// }
 
-// TODO implement a builder for optional parameters?
-pub fn list<T: RPCClient>(client: &T,
-                          filter_by: Option<ListPaperDocsFilterBy>,
-                          sort_by: Option<ListPaperDocsSortBy>,
-                          sort_order: Option<ListPaperDocsSortOrder>,
-                          limit: usize)
-                          -> Result<Response<ListPaperDocsResponse>> {
-    let url = Url::parse(BASE_URL)?
-        .join("list")?;
-    println!("{}", url);
+// // TODO implement a builder for optional parameters?
+// pub fn list<T: RPCClient>(client: &T,
+//                           filter_by: Option<ListPaperDocsFilterBy>,
+//                           sort_by: Option<ListPaperDocsSortBy>,
+//                           sort_order: Option<ListPaperDocsSortOrder>,
+//                           limit: usize)
+//                           -> Result<Response<ListPaperDocsResponse>> {
+//     let url = Url::parse(BASE_URL)?
+//         .join("list")?;
+//     println!("{}", url);
 
-    client.rpc_request(url,
-                       &ListPaperDocsArgs {
-                           filter_by: filter_by,
-                           sort_by: sort_by,
-                           sort_order: sort_order,
-                           limit: limit,
-                       })
-}
+//     client.rpc_request(url,
+//                        &ListPaperDocsArgs {
+//                            filter_by: filter_by,
+//                            sort_by: sort_by,
+//                            sort_order: sort_order,
+//                            limit: limit,
+//                        })
+// }
 
-pub fn list_continue<T: RPCClient>(client: &T,
-                                   cursor: &str)
-                                   -> Result<Response<ListPaperDocsResponse>> {
-    let url = Url::parse(BASE_URL)?
-        .join("list/")?
-        .join("continue")?;
-    println!("{}", url);
+// pub fn list_continue<T: RPCClient>(client: &T,
+//                                    cursor: &str)
+//                                    -> Result<Response<ListPaperDocsResponse>> {
+//     let url = Url::parse(BASE_URL)?
+//         .join("list/")?
+//         .join("continue")?;
+//     println!("{}", url);
 
-    client.rpc_request(url,
-                       &ListPaperDocsContinueArgs { cursor: cursor.to_owned() })
-}
+//     client.rpc_request(url,
+//                        &ListPaperDocsContinueArgs { cursor: cursor.to_owned() })
+// }
 
-pub fn permanently_delete<T: RPCClient>(client: &T, doc_id: &str) -> Result<Response<()>> {
-    let url = Url::parse(BASE_URL)?
-        .join("permanently_delete")?;
-    println!("{}", url);
+// pub fn permanently_delete<T: RPCClient>(client: &T, doc_id: &str) -> Result<Response<()>> {
+//     let url = Url::parse(BASE_URL)?
+//         .join("permanently_delete")?;
+//     println!("{}", url);
 
-    client.rpc_request(url, &RefPaperDoc { doc_id: doc_id.to_owned() })
-}
+//     client.rpc_request(url, &RefPaperDoc { doc_id: doc_id.to_owned() })
+// }
 
-pub fn get_sharing_policy<T: RPCClient>(client: &T,
-                                        doc_id: &str)
-                                        -> Result<Response<SharingPolicy>> {
-    let url = Url::parse(BASE_URL)?
-        .join("sharing_policy/get")?;
-    println!("{}", url);
+// pub fn get_sharing_policy<T: RPCClient>(client: &T,
+//                                         doc_id: &str)
+//                                         -> Result<Response<SharingPolicy>> {
+//     let url = Url::parse(BASE_URL)?
+//         .join("sharing_policy/get")?;
+//     println!("{}", url);
 
-    client.rpc_request(url, &RefPaperDoc { doc_id: doc_id.to_owned() })
-}
+//     client.rpc_request(url, &RefPaperDoc { doc_id: doc_id.to_owned() })
+// }
 
-pub fn set_sharing_policy<T: RPCClient>(client: &T,
-                                        doc_id: &str,
-                                        public_sharing_policy: Option<SharingPublicPolicyType>,
-                                        team_sharing_policy: Option<SharingTeamPolicyType>)
-                                        -> Result<Response<()>> {
-    let url = Url::parse(BASE_URL)?
-        .join("sharing_policy/set")?;
-    println!("{}", url);
+// pub fn set_sharing_policy<T: RPCClient>(client: &T,
+//                                         doc_id: &str,
+//                                         public_sharing_policy: Option<SharingPublicPolicyType>,
+//                                         team_sharing_policy: Option<SharingTeamPolicyType>)
+//                                         -> Result<Response<()>> {
+//     let url = Url::parse(BASE_URL)?
+//         .join("sharing_policy/set")?;
+//     println!("{}", url);
 
-    client.rpc_request(url,
-                       &PaperDocSharingPolicy {
-                           doc_id: doc_id.to_owned(),
-                           sharing_policy: SharingPolicy {
-                               public_sharing_policy: public_sharing_policy,
-                               team_sharing_policy: team_sharing_policy,
-                           },
-                       })
-}
+//     client.rpc_request(url,
+//                        &PaperDocSharingPolicy {
+//                            doc_id: doc_id.to_owned(),
+//                            sharing_policy: SharingPolicy {
+//                                public_sharing_policy: public_sharing_policy,
+//                                team_sharing_policy: team_sharing_policy,
+//                            },
+//                        })
+// }
 
-pub fn update<T: ContentUploadClient, C: Into<Body>>
-    (client: &T,
-     doc_id: &str,
-     doc_update_policy: PaperDocUpdatePolicy,
-     revision: i64,
-     import_format: ImportFormat,
-     content: C)
-     -> Result<Response<PaperDocCreateUpdateResult>> {
+// pub fn update<T: ContentUploadClient, C: Into<Body>>
+//     (client: &T,
+//      doc_id: &str,
+//      doc_update_policy: PaperDocUpdatePolicy,
+//      revision: i64,
+//      import_format: ImportFormat,
+//      content: C)
+//      -> Result<Response<PaperDocCreateUpdateResult>> {
 
-    let url = Url::parse(BASE_URL)?
-        .join("update")?;
-    println!("{}", url);
+//     let url = Url::parse(BASE_URL)?
+//         .join("update")?;
+//     println!("{}", url);
 
-    client.content_upload_request(url,
-                                  PaperDocUpdateArgs {
-                                      doc_id: doc_id.to_owned(),
-                                      doc_update_policy: doc_update_policy,
-                                      revision: revision,
-                                      import_format: import_format,
-                                  },
-                                  content)
-}
+//     client.content_upload_request(url,
+//                                   PaperDocUpdateArgs {
+//                                       doc_id: doc_id.to_owned(),
+//                                       doc_update_policy: doc_update_policy,
+//                                       revision: revision,
+//                                       import_format: import_format,
+//                                   },
+//                                   content)
+// }
 
-pub fn users_add<T: RPCClient + Clone>(client: &T,
-                                       doc_id: &str)
-                                       -> AddPaperDocUserRequestBuilder<T> {
-    AddPaperDocUserRequestBuilder::new(client, doc_id)
-}
+// pub fn users_add<T: RPCClient + Clone>(client: &T,
+//                                        doc_id: &str)
+//                                        -> AddPaperDocUserRequestBuilder<T> {
+//     AddPaperDocUserRequestBuilder::new(client, doc_id)
+// }
 
-pub fn users_list<T: RPCClient>(client: &T,
-                                doc_id: &str,
-                                limit: i32,
-                                filter_by: UserOnPaperDocFilter)
-                                -> Result<Response<ListUsersOnPaperDocResponse>> {
-    let url = Url::parse(BASE_URL)?.join("users/list")?;
-    client.rpc_request(url,
-                       &ListUsersOnPaperDocArgs {
-                           doc_id: doc_id.to_owned(),
-                           limit: limit,
-                           filter_by: filter_by,
-                       })
-}
+// pub fn users_list<T: RPCClient>(client: &T,
+//                                 doc_id: &str,
+//                                 limit: i32,
+//                                 filter_by: UserOnPaperDocFilter)
+//                                 -> Result<Response<ListUsersOnPaperDocResponse>> {
+//     let url = Url::parse(BASE_URL)?.join("users/list")?;
+//     client.rpc_request(url,
+//                        &ListUsersOnPaperDocArgs {
+//                            doc_id: doc_id.to_owned(),
+//                            limit: limit,
+//                            filter_by: filter_by,
+//                        })
+// }
 
-pub fn users_list_continue<T: RPCClient>(client: &T,
-                                         doc_id: &str,
-                                         cursor: &str)
-                                         -> Result<Response<ListUsersOnPaperDocResponse>> {
-    let url = Url::parse(BASE_URL)?.join("users/list/continue")?;
-    client.rpc_request(url,
-                       &ListUsersOnPaperDocContinueArgs {
-                           doc_id: doc_id.to_owned(),
-                           cursor: cursor.to_owned(),
-                       })
-}
+// pub fn users_list_continue<T: RPCClient>(client: &T,
+//                                          doc_id: &str,
+//                                          cursor: &str)
+//                                          -> Result<Response<ListUsersOnPaperDocResponse>> {
+//     let url = Url::parse(BASE_URL)?.join("users/list/continue")?;
+//     client.rpc_request(url,
+//                        &ListUsersOnPaperDocContinueArgs {
+//                            doc_id: doc_id.to_owned(),
+//                            cursor: cursor.to_owned(),
+//                        })
+// }
 
-pub fn users_remove<T: RPCClient>(client: &T,
-                                  doc_id: &str,
-                                  member: &MemberSelector)
-                                  -> Result<Response<()>> {
-    let url = Url::parse(BASE_URL)?.join("users/remove")?;
-    client.rpc_request(url,
-                       &RemovePaperDocUser {
-                           doc_id: doc_id.to_owned(),
-                           member: member.clone(),
-                       })
-}
+// pub fn users_remove<T: RPCClient>(client: &T,
+//                                   doc_id: &str,
+//                                   member: &MemberSelector)
+//                                   -> Result<Response<()>> {
+//     let url = Url::parse(BASE_URL)?.join("users/remove")?;
+//     client.rpc_request(url,
+//                        &RemovePaperDocUser {
+//                            doc_id: doc_id.to_owned(),
+//                            member: member.clone(),
+//                        })
+// }
 
 
 /**

--- a/src/paper/users.rs
+++ b/src/paper/users.rs
@@ -111,7 +111,7 @@ impl<T> AddPaperDocUserRequestBuilder<T>
         self
     }
 
-    pub fn send(&self) -> Result<Response<Vec<AddPaperDocUserMemberResult>>> {
+    pub fn send(&self) -> Result<Response<Vec<AddPaperDocUserMemberResult>, ()>> {
         let url = Url::parse(super::BASE_URL)?.join("users/add")?;
         self.client.rpc_request(url,
                                 AddPaperDocUser {

--- a/tests/paper.rs
+++ b/tests/paper.rs
@@ -183,3 +183,13 @@ fn test_users_add_list_remove() {
                "jfokkan@gmail.com");
     assert_eq!(users_list_after_remove.body.invitees.len(), 0);
 }
+
+#[test]
+fn test_cursor_error() {
+    let error_json = r#"{
+    "error_summary": "other/...",
+    "error": {
+        "cursor_error": {".tag": "expired_cursor"}
+    }
+}"#;
+}


### PR DESCRIPTION

Each endpoint has a response type or a specific api error type for that endpoint, lets call it `ExampleAPIError` from now on.

My functions have signatures such as this:
`fn example_api() -> Result<Response<ExampleResult>>`

The result comes from the generated error module using error_chain and the response is a generic struct that wraps a body as follows
```
pub struct Response<T> {
    pub body: T,
}
```

I would like to return the potential error deserialized from the `example_api()` function since we already have that information
ahead of time. I feel like I have 3 possible solutions:
1. Make the api error part of the error_chain error in a big `APIErrors` enum for all the type 
of API errors and document that this `example_api()` can return errors of that type.
The disadvantage here is that I feel like I am losing some information since the error
seems important enough that it should maybe be encoded in function signature.

2. Make the Response an enum that holds either a body or an APIError. This is a little 
analogous to the Result type but the disadvantage is that we are duplicating the error handling 
since a user of that function would have to handle errors twice and since my `Response` type isn't a 
result type won't benefit from using the `?` operator.

3. Similar to the above, make the Response an enum but map the error to the error case of the Result. 
This is quite ugly and will also confuse users since even though the Response type is an enum, 
it should essentially never actually be the error case. 
